### PR TITLE
RavenDB-19387 Helm: Register client certificate

### DIFF
--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -15,8 +15,11 @@ echo "Extracting files from the package..."
 mkdir /ravendb/ravendb-setup-package-copy
 cd /ravendb
 unzip -qq pack.zip -d ./ravendb-setup-package-copy/ > /dev/null
-cd ravendb-setup-package-copy/A
 
+
+cd ravendb-setup-package-copy
+last_node_tag_caps="$(find . -maxdepth 1 -type d -print | tail -1 | sed s-./--)"
+cd "$last_node_tag_caps"
 
 urls=()
 tags=()
@@ -51,7 +54,7 @@ for tag in "${tags[@]}" ; do
   tag_index="$(curl https://"${tags[0]}"."$domain_name"/cluster/topology -Ss --cert cert.pem |  jq ".Topology.AllNodes | keys | index( \"$tag\" )" )"
   echo "$tag index is: $tag_index"
   if [ "$tag" != "${tags[0]}" ] && [ "$tag_index" == "null" ]; then
-      urls+=("https://a.$domain_name/admin/cluster/node?url=https%3A%2F%2F$tag.$domain_name&tag=$(echo "$tag" | tr '[:lower:]' '[:upper:]')")
+      urls+=("https://${tags[0]}.$domain_name/admin/cluster/node?url=https%3A%2F%2F$tag.$domain_name&tag=$(echo "$tag" | tr '[:lower:]' '[:upper:]')")
   fi
 done
 

--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -56,12 +56,10 @@ for tag in "${tags[@]}" ; do
 done
 
 
-echo "Sending requests..."
+echo "Building cluster..."
 echo "${urls[@]}"
 for url in "${urls[@]}"
 do
-    echo "Checking if node A is connected with $url"
-    echo "Sending request connecting node A with node under the $url"
     curl -L -X PUT "$url" --cert cert.pem
 done
 

--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -74,7 +74,7 @@ echo "Current cluster size is $cluster_size. Expected cluster size: ${#tags[@]}"
 done
 
 
-echo "Updating client certificate..."
+echo "Registering admin client certificate..."
 node_tag_upper="$(echo "${tags[0]}" | tr '[:lower:]' '[:upper:]')"
 /opt/RavenDB/Server/rvn put-client-certificate \
     "https://${tags[0]}.$domain_name" /ravendb/ravendb-setup-package-copy/"$node_tag_upper"/*.pfx /ravendb/ravendb-setup-package-copy/admin.client.certificate.*.pfx

--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -50,7 +50,7 @@ echo "Figuring out which tags should be called..."
 for tag in "${tags[@]}" ; do
   tag_index="$(curl https://"${tags[0]}"."$domain_name"/cluster/topology -Ss --cert cert.pem |  jq ".Topology.AllNodes | keys | index( \"$tag\" )" )"
   echo "$tag index is: $tag_index"
-  if [ "$tag" != "a" ] && [ "$tag_index" == "null" ]; then
+  if [ "$tag" != "${tags[0]}" ] && [ "$tag_index" == "null" ]; then
       urls+=("https://a.$domain_name/admin/cluster/node?url=https%3A%2F%2F$tag.$domain_name&tag=$(echo "$tag" | tr '[:lower:]' '[:upper:]')")
   fi
 done

--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -3,42 +3,39 @@
 set -e
 
 echo "Installing prerequisites..."
-# prerequisites
 apt-get update
 apt-get install curl unzip jq -y
 
-# copy the package from readonly volume
+
 echo "Copying /ravendb/ravendb-setup-package-readonly/pack.zip to the /ravendb folder..."
 cp -v /ravendb/ravendb-setup-package/*.zip /ravendb/pack.zip
 
-# unzip the pack
+
 echo "Extracting files from the pack..."
 mkdir /ravendb/ravendb-setup-package-copy
 cd /ravendb
 unzip -qq pack.zip -d ./ravendb-setup-package-copy/ > /dev/null
 cd ravendb-setup-package-copy/A
 
-# todo: register a client ceritifacte
 
 urls=()
 tags=()
 domain_name="$(cat /ravendb/scripts/domain)"
 
+
+echo "Converting pfx to pem..."
+openssl pkcs12 -in "$(find ./*certificate*)" -password pass: -out cert.pem -nodes
+
+echo "Discovering tags..."
 for i in ../* ; do
   if [ -d "$i" ]; then
     tag="$(basename "$i" | tr '[:upper:]' '[:lower:]')"
     tags+=("$tag")
-    if [ "$tag" != "a" ]; then
-        urls+=("https://a.$domain_name/admin/cluster/node?url=https%3A%2F%2F$tag.$domain_name&tag=$(echo "$tag" | tr '[:lower:]' '[:upper:]')")
-    fi
   fi
 done
 
-# convert .pfx to .pem
-echo "Converting pfx to pem..."
-openssl pkcs12 -in "$(find ./*certificate*)" -password pass: -out cert.pem -nodes -legacy
 
-# send requests that will create cluster using converted certificate 
+echo "Waiting for nodes to stand-up..."
 for tag in "${tags[@]}"
 do
 while ! curl "https://$tag.$domain_name/setup/alive"
@@ -48,10 +45,39 @@ do
 done
 done
 
+
+echo "Figuring out which tags should be called..."
+for tag in "${tags[@]}" ; do
+  tag_index="$(curl https://"${tags[0]}"."$domain_name"/cluster/topology -Ss --cert cert.pem |  jq ".Topology.AllNodes | keys | index( \"$tag\" )" )"
+  echo "$tag index is: $tag_index"
+  if [ "$tag" != "a" ] && [ "$tag_index" == "null" ]; then
+      urls+=("https://a.$domain_name/admin/cluster/node?url=https%3A%2F%2F$tag.$domain_name&tag=$(echo "$tag" | tr '[:lower:]' '[:upper:]')")
+  fi
+done
+
+
 echo "Sending requests..."
 echo "${urls[@]}"
 for url in "${urls[@]}"
 do
+    echo "Checking if node A is connected with $url"
     echo "Sending request connecting node A with node under the $url"
     curl -L -X PUT "$url" --cert cert.pem
 done
+
+
+cluster_size="1"
+while [ "$cluster_size" != "${#tags[@]}" ]
+do
+sleep 1
+cluster_size=$(curl "https://${tags[0]}.$domain_name/cluster/topology" -Ss --cert cert.pem | jq ".Topology.AllNodes | keys | length")
+echo "Waiting for cluster build-up..."
+echo "Current cluster size is $cluster_size. Expected cluster size: ${#tags[@]}"
+done
+
+
+echo "Updating client certificate..."
+node_tag_upper="$(echo "${tags[0]}" | tr '[:lower:]' '[:upper:]')"
+/opt/RavenDB/Server/rvn put-client-certificate \
+    "https://${tags[0]}.$domain_name" /ravendb/ravendb-setup-package-copy/"$node_tag_upper"/*.pfx /ravendb/ravendb-setup-package-copy/admin.client.certificate.*.pfx
+

--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -11,7 +11,7 @@ echo "Copying /ravendb/ravendb-setup-package-readonly/pack.zip to the /ravendb f
 cp -v /ravendb/ravendb-setup-package/*.zip /ravendb/pack.zip
 
 
-echo "Extracting files from the pack..."
+echo "Extracting files from the package..."
 mkdir /ravendb/ravendb-setup-package-copy
 cd /ravendb
 unzip -qq pack.zip -d ./ravendb-setup-package-copy/ > /dev/null
@@ -23,7 +23,7 @@ tags=()
 domain_name="$(cat /ravendb/scripts/domain)"
 
 
-echo "Converting pfx to pem..."
+echo "Converting server certificate .pfx file to .pem..."
 openssl pkcs12 -in "$(find ./*certificate*)" -password pass: -out cert.pem -nodes
 
 echo "Discovering tags..."

--- a/charts/ravendb-cluster/scripts/create-cluster.sh
+++ b/charts/ravendb-cluster/scripts/create-cluster.sh
@@ -17,9 +17,8 @@ cd /ravendb
 unzip -qq pack.zip -d ./ravendb-setup-package-copy/ > /dev/null
 
 
-cd ravendb-setup-package-copy
-last_node_tag_caps="$(find . -maxdepth 1 -type d -print | tail -1 | sed s-./--)"
-cd "$last_node_tag_caps"
+first_node_tag_caps="$(find ravendb-setup-package-copy -maxdepth 1 -type d -printf '%P\n' | head -2 | tail -1)" 
+cd "ravendb-setup-package-copy/${first_node_tag_caps}"
 
 urls=()
 tags=()

--- a/charts/ravendb-cluster/templates/ravendb-create-cluster-pod.yaml
+++ b/charts/ravendb-cluster/templates/ravendb-create-cluster-pod.yaml
@@ -19,7 +19,8 @@ spec:
         secretName: ravendb-setup-package
   containers:
   - name: main
-    image: "ubuntu:latest" # todo: use lighter distro to run the scripts
+    image: "ravendb/ravendb:{{$.Values.ravenImageTag}}"
+    imagePullPolicy: {{ $.Values.imagePullPolicy }}
     command: ["/bin/bash"]
     args: ["/ravendb/scripts/create-cluster.sh"]
     volumeMounts:


### PR DESCRIPTION
Rebuilt the `create-cluster.sh` 
I've changed the image on the cluster creator from `ubuntu` to `ravendb`.
It won't work until RavenDB 5.3+ release with `rvn register-client-certificate` included